### PR TITLE
Ensure dig availability in n8n installer

### DIFF
--- a/n8n/n8n-installer.sh
+++ b/n8n/n8n-installer.sh
@@ -23,6 +23,18 @@ if ! command -v jq &>/dev/null; then
   "
 fi
 
+# Ensure dnsutils is installed for dig
+if ! command -v dig &>/dev/null; then
+  gum spin --spinner dot --title "Installing dnsutils..." -- bash -c "
+    apt-get update &&
+    apt-get install -y dnsutils
+  "
+  if ! command -v dig &>/dev/null; then
+    gum style --foreground 9 "The 'dig' command is required but could not be installed. Aborting."
+    exit 1
+  fi
+fi
+
 # Prompt user to choose an action
 ACTION=$(gum choose "Install n8n" "Update n8n" "Show current n8n version")
 


### PR DESCRIPTION
## Summary
- Install dnsutils before using dig
- Abort with clear error if dig remains missing

## Testing
- `bash -n n8n/n8n-installer.sh`
- `shellcheck n8n/n8n-installer.sh` *(fails: shellcheck not installed, apt repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689d93c3507c83308d8bd6ea73c1c85b