### PR TITLE
fix(goclaw): make GITHUB_RAW branch configurable via GOCLAW_BRANCH en…

### DIFF
--- a/goclaw/goclaw.sh
+++ b/goclaw/goclaw.sh
@@ -17,7 +17,9 @@ hr()  { echo -e "${C}───────────────────�
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONF_FILE="${HOME}/.goclaw.conf"
-GITHUB_RAW="https://raw.githubusercontent.com/comchienlab/dotfiles/main/goclaw"
+GITHUB_REPO="comchienlab/dotfiles"
+GITHUB_BRANCH="${GOCLAW_BRANCH:-main}"
+GITHUB_RAW="https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_BRANCH}/goclaw"
 
 # ── Defaults ───────────────────────────────────────────────────────
 VPS_USER="root"


### PR DESCRIPTION
…v var

Allows testing from non-main branches:
  GOCLAW_BRANCH=feat/... bash <(curl ...)

Defaults to 'main' for production use after merge.

https://claude.ai/code/session_01Q1LWrfh3hz2Aw4AmXPdH9B